### PR TITLE
test: ensure return semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Fortunately since the library returns iterables rather than raw iterators this c
 
 It is possible when defining a generator function to return a value in addition to yielding values:
 
-```
+```typescript
 function* f() {
   let n = 2;
   while (n--) {
@@ -88,7 +88,7 @@ while (result.done) {
 
 will log out
 
-```
+```typescript
 { done: false, value: 2 }
 { done: false, value: 1 }
 { done: false, value: 0 }
@@ -97,7 +97,7 @@ will log out
 
 HOWEVER, these returned values are mostly ignored by constructs in the language that process iterators/iterables:
 
-```
+```typescript
 const arr = Array.from(f()); // [2, 1, 0], no 7
 for (const n of f()) {
   console.log(n); // logs 2, 1. 0 but not 7

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "format": "prettier . --write",
     "lint": "eslint ./src",
     "pre": "npm run-script clean && npm run-script build && npm test && rm -rf node_modules",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [
     "generators",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Library functions for working with generators",
   "sideEffects": false,
+  "private": false,
   "exports": {
     ".": {
       "require": "./dist/index.js",
@@ -45,7 +46,7 @@
     "clean": "rm -rf ./dist",
     "format": "prettier . --write",
     "lint": "eslint ./src",
-    "prepublish": "npm run-script clean && npm run-script build && npm test && rm -rf node_modules",
+    "pre": "npm run-script clean && npm run-script build && npm test && rm -rf node_modules",
     "test": "vitest run"
   },
   "keywords": [

--- a/spec/concat.spec.ts
+++ b/spec/concat.spec.ts
@@ -5,4 +5,80 @@ describe("concat", () => {
   it("should concatenate sequences", () => {
     expect([...concat(["a"], "bcd")]).toEqual(["a", "b", "c", "d"]);
   });
+
+  it("should respect the return method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const g = function* () {
+      let n = 0;
+      while (n < 3) {
+        yield n++;
+      }
+    };
+
+    const iter = concat(f, g)[Symbol.iterator]();
+    expect(iter.return).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number> = iter.next();
+    while (!done) {
+      result.push(value);
+      if (result.length === 2) {
+        const res = iter.return?.(9);
+        if (res) {
+          ({ done, value } = res);
+        }
+      } else {
+        ({ done, value } = iter.next());
+      }
+    }
+
+    expect(value).toBe(9);
+    expect(result).toEqual([1, 0]);
+  });
+
+  it("should respect the throw method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const g = function* () {
+      let n = 0;
+      while (n < 3) {
+        yield n++;
+      }
+    };
+
+    const iter = concat(f, g)[Symbol.iterator]();
+    expect(iter.throw).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number | undefined> = {
+      done: false,
+      value: undefined,
+    };
+
+    let passed = false;
+    while (!done) {
+      ({ done, value } = iter.next());
+      result.push(value);
+      if (result.length === 2) {
+        try {
+          iter.throw?.(new Error("stopping"));
+        } catch (_err) {
+          passed = true;
+        }
+        break;
+      }
+    }
+
+    expect(result).toEqual([1, 0]);
+    expect(passed).toBe(true);
+  });
 });

--- a/spec/drop.spec.ts
+++ b/spec/drop.spec.ts
@@ -7,6 +7,22 @@ describe("drop", () => {
     expect([...drop(1, [])]).toEqual([]);
     expect([...drop(1, [1])]).toEqual([]);
   });
+
+  it("supports the return value semantic of generator functions", () => {
+    const f = function* () {
+      let n = 3;
+      while (n--) {
+        yield n;
+      }
+
+      return 7;
+    };
+
+    const iter = drop(2, f)[Symbol.iterator]();
+    let { done, value } = iter.next();
+    while (!done) ({ done, value } = iter.next());
+    expect(value).toBe(7);
+  });
 });
 
 describe("dropWhile", () => {
@@ -16,5 +32,21 @@ describe("dropWhile", () => {
     );
     expect([...dropWhile((x) => Boolean(x % 2), [1, 3, 5])]).toEqual([]);
     expect([...dropWhile((x) => Boolean(x % 2), [])]).toEqual([]);
+  });
+
+  it("supports the return value semantic of generator functions", () => {
+    const f = function* () {
+      let n = 3;
+      while (n--) {
+        yield n;
+      }
+
+      return 7;
+    };
+
+    const iter = dropWhile((n: number) => n === 2, f)[Symbol.iterator]();
+    let { done, value } = iter.next();
+    while (!done) ({ done, value } = iter.next());
+    expect(value).toBe(7);
   });
 });

--- a/spec/drop.spec.ts
+++ b/spec/drop.spec.ts
@@ -23,6 +23,68 @@ describe("drop", () => {
     while (!done) ({ done, value } = iter.next());
     expect(value).toBe(7);
   });
+
+  it("should respect the return method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = drop(1, f)[Symbol.iterator]();
+    expect(iter.return).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number> = iter.next();
+    while (!done) {
+      result.push(value);
+      if (result.length === 1) {
+        const res = iter.return?.(9);
+        if (res) {
+          ({ done, value } = res);
+        }
+      } else {
+        ({ done, value } = iter.next());
+      }
+    }
+
+    expect(value).toBe(9);
+    expect(result).toEqual([0]);
+  });
+
+  it("should respect the throw method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = drop(1, f)[Symbol.iterator]();
+    expect(iter.throw).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number | undefined> = {
+      done: false,
+      value: undefined,
+    };
+
+    let passed = false;
+    while (!done) {
+      ({ done, value } = iter.next());
+      result.push(value);
+      if (result.length === 1) {
+        try {
+          iter.throw?.(new Error("stopping"));
+        } catch (_err) {
+          passed = true;
+        }
+        break;
+      }
+    }
+
+    expect(result).toEqual([0]);
+    expect(passed).toBe(true);
+  });
 });
 
 describe("dropWhile", () => {
@@ -48,5 +110,67 @@ describe("dropWhile", () => {
     let { done, value } = iter.next();
     while (!done) ({ done, value } = iter.next());
     expect(value).toBe(7);
+  });
+
+  it("should respect the return method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = dropWhile((n: number) => n === 2, f)[Symbol.iterator]();
+    expect(iter.return).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number> = iter.next();
+    while (!done) {
+      result.push(value);
+      if (result.length === 1) {
+        const res = iter.return?.(9);
+        if (res) {
+          ({ done, value } = res);
+        }
+      } else {
+        ({ done, value } = iter.next());
+      }
+    }
+
+    expect(value).toBe(9);
+    expect(result).toEqual([1]);
+  });
+
+  it("should respect the throw method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = dropWhile((n: number) => n === 2, f)[Symbol.iterator]();
+    expect(iter.throw).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number | undefined> = {
+      done: false,
+      value: undefined,
+    };
+
+    let passed = false;
+    while (!done) {
+      ({ done, value } = iter.next());
+      result.push(value);
+      if (result.length === 1) {
+        try {
+          iter.throw?.(new Error("stopping"));
+        } catch (_err) {
+          passed = true;
+        }
+        break;
+      }
+    }
+
+    expect(result).toEqual([1]);
+    expect(passed).toBe(true);
   });
 });

--- a/spec/filter.spec.ts
+++ b/spec/filter.spec.ts
@@ -38,4 +38,66 @@ describe("filter", () => {
     while (!done) ({ done, value } = evenIter.next());
     expect(value).toBeUndefined();
   });
+
+  it("should respect the return method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = filter((n: number) => n !== 2, f)[Symbol.iterator]();
+    expect(iter.return).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number> = iter.next();
+    while (!done) {
+      result.push(value);
+      if (result.length === 1) {
+        const res = iter.return?.(9);
+        if (res) {
+          ({ done, value } = res);
+        }
+      } else {
+        ({ done, value } = iter.next());
+      }
+    }
+
+    expect(value).toBe(9);
+    expect(result).toEqual([1]);
+  });
+
+  it("should respect the throw method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = filter((n: number) => n !== 2, f)[Symbol.iterator]();
+    expect(iter.throw).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number | undefined> = {
+      done: false,
+      value: undefined,
+    };
+
+    let passed = false;
+    while (!done) {
+      ({ done, value } = iter.next());
+      result.push(value);
+      if (result.length === 1) {
+        try {
+          iter.throw?.(new Error("stopping"));
+        } catch (_err) {
+          passed = true;
+        }
+        break;
+      }
+    }
+
+    expect(result).toEqual([1]);
+    expect(passed).toBe(true);
+  });
 });

--- a/spec/filter.spec.ts
+++ b/spec/filter.spec.ts
@@ -1,8 +1,41 @@
 import { filter } from "../src";
 import { describe, it, expect } from "vitest";
 
+const isOdd = (n: number): boolean => Boolean(n % 2);
+const isEven = (n: number) => !isOdd(n);
+
 describe("filter", () => {
   it("should return the items from a sequence that match a predicate", () => {
     expect(Array.from(filter(Boolean, [0, 1, 2]))).toEqual([1, 2]);
+  });
+
+  it("supports the return value semantic of generator functions", () => {
+    const f = function* () {
+      let n = 3;
+      while (n--) {
+        yield n;
+      }
+
+      return 7;
+    };
+
+    const iter = filter(isOdd, f)[Symbol.iterator]();
+    let { done, value } = iter.next();
+    while (!done) ({ done, value } = iter.next());
+    expect(value).toBe(7);
+
+    const g = function* () {
+      let n = 3;
+      while (n--) {
+        yield n;
+      }
+
+      return 7;
+    };
+
+    const evenIter = filter(isEven, g)[Symbol.iterator]();
+    ({ done, value } = evenIter.next());
+    while (!done) ({ done, value } = evenIter.next());
+    expect(value).toBeUndefined();
   });
 });

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -3,7 +3,7 @@ import { filter, map, take } from "../src";
 
 const square = (n: number): number => n * n;
 const isOdd = (n: number): boolean => n % 2 !== 0;
-const inf = function*() {
+const inf = function* () {
   let i = 0;
   while (true) {
     yield ++i; // all positive integers
@@ -19,8 +19,8 @@ const compose =
     f: F,
     g: G,
   ) =>
-    (x: Parameters<G>[0]) =>
-      f(g(x));
+  (x: Parameters<G>[0]) =>
+    f(g(x));
 
 describe("generator functions", () => {
   it("should compose the expected way", () => {

--- a/spec/map.spec.ts
+++ b/spec/map.spec.ts
@@ -8,4 +8,20 @@ describe("map", () => {
     expect(Array.from(map(square, [1, 2, 3]))).toEqual([1, 4, 9]);
     expect(Array.from(map(String, [1, 2, 3]))).toEqual(["1", "2", "3"]);
   });
+
+  it("supports the return value semantic of generator functions", () => {
+    const f = function* () {
+      let n = 3;
+      while (n--) {
+        yield n;
+      }
+
+      return 7;
+    };
+
+    const iter = map((n: number) => n + 1, f)[Symbol.iterator]();
+    let { done, value } = iter.next();
+    while (!done) ({ done, value } = iter.next());
+    expect(value).toBe(8);
+  });
 });

--- a/spec/map.spec.ts
+++ b/spec/map.spec.ts
@@ -24,4 +24,66 @@ describe("map", () => {
     while (!done) ({ done, value } = iter.next());
     expect(value).toBe(8);
   });
+
+  it("should respect the return method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = map((n: number) => n + 1, f)[Symbol.iterator]();
+    expect(iter.return).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number> = iter.next();
+    while (!done) {
+      result.push(value);
+      if (result.length === 1) {
+        const res = iter.return?.(9);
+        if (res) {
+          ({ done, value } = res);
+        }
+      } else {
+        ({ done, value } = iter.next());
+      }
+    }
+
+    expect(value).toBe(9);
+    expect(result).toEqual([2]);
+  });
+
+  it("should respect the throw method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = map((n: number) => n + 1, f)[Symbol.iterator]();
+    expect(iter.throw).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number | undefined> = {
+      done: false,
+      value: undefined,
+    };
+
+    let passed = false;
+    while (!done) {
+      ({ done, value } = iter.next());
+      result.push(value);
+      if (result.length === 1) {
+        try {
+          iter.throw?.(new Error("stopping"));
+        } catch (_err) {
+          passed = true;
+        }
+        break;
+      }
+    }
+
+    expect(result).toEqual([2]);
+    expect(passed).toBe(true);
+  });
 });

--- a/spec/partition.spec.ts
+++ b/spec/partition.spec.ts
@@ -1,6 +1,8 @@
 import { partition, partitionBy } from "../src";
 import { describe, it, expect } from "vitest";
 
+const isOdd = (n: number): boolean => Boolean(n % 2);
+
 describe("partition", () => {
   it("should split the iterator into n-sized chunks", () => {
     expect(
@@ -36,6 +38,65 @@ describe("partition", () => {
     }
     expect(value).toEqual([7]);
   });
+
+  it("should respect the return method of iterators", () => {
+    const f = function* () {
+      let n = 4;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = partition(2, f)[Symbol.iterator]();
+    expect(iter.return).toBeDefined();
+    const result: number[][] = [];
+    let { done, value }: IteratorResult<Iterable<number>> = iter.next();
+    while (!done) {
+      result.push(value);
+      if (result.length === 1) {
+        const res = iter.return?.([9]);
+        if (res) {
+          ({ done, value } = res);
+        }
+      } else {
+        ({ done, value } = iter.next());
+      }
+    }
+
+    expect(value).toEqual([9]);
+    expect([...result[0]]).toEqual([3, 2]);
+  });
+
+  it("should respect the throw method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = partition(2, f)[Symbol.iterator]();
+    expect(iter.throw).toBeDefined();
+    const result: number[][] = [];
+    let { done, value }: IteratorResult<Iterable<number>> = iter.next();
+
+    let passed = false;
+    while (!done) {
+      result.push(value);
+      if (result.length === 1) {
+        try {
+          iter.throw?.(new Error("stopping"));
+        } catch (_err) {
+          passed = true;
+        }
+        break;
+      }
+      ({ done, value } = iter.next());
+    }
+
+    expect(result).toEqual([[1, 0]]);
+    expect(passed).toBe(true);
+  });
 });
 
 describe("partitionBy", () => {
@@ -61,7 +122,6 @@ describe("partitionBy", () => {
       return 7;
     };
 
-    const isOdd = (n: number): boolean => Boolean(n % 2);
     const [odds] = partitionBy(isOdd, f)[Symbol.iterator]();
     let value = 0;
     let done: boolean | undefined = false;
@@ -70,5 +130,66 @@ describe("partitionBy", () => {
       ({ value, done } = iter.next());
     }
     expect(value).toBe(7);
+  });
+
+  it("should respect the return method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const [iterable] = partitionBy(isOdd, f)[Symbol.iterator]();
+    const iter = iterable[Symbol.iterator]();
+    expect(iter.return).toBeDefined();
+    const result: number[][] = [];
+    let { done, value }: IteratorResult<number> = iter.next();
+    while (!done) {
+      result.push(value);
+      if (result.length === 1) {
+        const res = iter.return?.(9);
+        if (res) {
+          ({ done, value } = res);
+        }
+      } else {
+        ({ done, value } = iter.next());
+      }
+    }
+
+    expect(value).toBe(9);
+    expect(result).toEqual([1]);
+  });
+
+  it("should respect the throw method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const [iterable] = partitionBy(isOdd, f)[Symbol.iterator]();
+    const iter = iterable[Symbol.iterator]();
+    expect(iter.throw).toBeDefined();
+    const result: number[][] = [];
+    let { done, value }: IteratorResult<number> = iter.next();
+
+    let passed = false;
+    while (!done) {
+      result.push(value);
+      if (result.length === 1) {
+        try {
+          iter.throw?.(new Error("stopping"));
+        } catch (_err) {
+          passed = true;
+        }
+        break;
+      }
+      ({ done, value } = iter.next());
+    }
+
+    expect(result).toEqual([1]);
+    expect(passed).toBe(true);
   });
 });

--- a/spec/partition.spec.ts
+++ b/spec/partition.spec.ts
@@ -16,6 +16,26 @@ describe("partition", () => {
       Array.from(partition(2, [1, 2, 3])).map((x) => Array.from(x)),
     ).toEqual([[1, 2], [3]]);
   });
+
+  it("supports the return value semantic of generator functions", () => {
+    const f = function* () {
+      let n = 3;
+      while (n--) {
+        yield n;
+      }
+
+      return [7];
+    };
+
+    let value: number[] = [];
+    let done: boolean | undefined = false;
+    const parted = partition(2, f);
+    const iter = parted[Symbol.iterator]();
+    while (!done) {
+      ({ value, done } = iter.next());
+    }
+    expect(value).toEqual([7]);
+  });
 });
 
 describe("partitionBy", () => {
@@ -29,5 +49,26 @@ describe("partitionBy", () => {
     const [pass3, fail3] = partitionBy(Boolean, [1, 1, 1, 0, 0, 0, 0, 1]);
     expect(Array.from(pass3)).toEqual([1, 1, 1, 1]);
     expect(Array.from(fail3)).toEqual([0, 0, 0, 0]);
+  });
+
+  it("supports the return value semantic of generator functions", () => {
+    const f = function* () {
+      let n = 3;
+      while (n--) {
+        yield n;
+      }
+
+      return 7;
+    };
+
+    const isOdd = (n: number): boolean => Boolean(n % 2);
+    const [odds] = partitionBy(isOdd, f)[Symbol.iterator]();
+    let value = 0;
+    let done: boolean | undefined = false;
+    const iter = odds[Symbol.iterator]();
+    while (!done) {
+      ({ value, done } = iter.next());
+    }
+    expect(value).toBe(7);
   });
 });

--- a/spec/take.spec.ts
+++ b/spec/take.spec.ts
@@ -11,7 +11,7 @@ describe("take", () => {
   });
 
   it("should work with infinite sequences", () => {
-    const inf = function*() {
+    const inf = function* () {
       let i = 0;
       while (true) {
         yield ++i; // all positive integers
@@ -26,5 +26,25 @@ describe("takeWhile", () => {
   it("should return a sequence up until an item fails the predicate", () => {
     expect(Array.from(takeWhile(Boolean, [1, 2, 0]))).toEqual([1, 2]);
     expect(Array.from(takeWhile(Boolean, [1, 2]))).toEqual([1, 2]);
+  });
+
+  it("supports the return value semantic of generator functions", () => {
+    const f = function* () {
+      let n = 3;
+      while (n--) {
+        yield n;
+      }
+
+      return 7;
+    };
+
+    let value: number[] = [];
+    let done: boolean | undefined = false;
+    const parted = takeWhile((_n: number) => true, f);
+    const iter = parted[Symbol.iterator]();
+    while (!done) {
+      ({ value, done } = iter.next());
+    }
+    expect(value).toEqual(7);
   });
 });

--- a/spec/take.spec.ts
+++ b/spec/take.spec.ts
@@ -20,6 +20,68 @@ describe("take", () => {
 
     expect(Array.from(take(3, inf))).toEqual([1, 2, 3]);
   });
+
+  it("should respect the return method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = take(1, f)[Symbol.iterator]();
+    expect(iter.return).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number> = iter.next();
+    while (!done) {
+      result.push(value);
+      if (result.length === 1) {
+        const res = iter.return?.(9);
+        if (res) {
+          ({ done, value } = res);
+        }
+      } else {
+        ({ done, value } = iter.next());
+      }
+    }
+
+    expect(value).toBe(9);
+    expect(result).toEqual([1]);
+  });
+
+  it("should respect the throw method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = take(1, f)[Symbol.iterator]();
+    expect(iter.throw).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number | undefined> = {
+      done: false,
+      value: undefined,
+    };
+
+    let passed = false;
+    while (!done) {
+      ({ done, value } = iter.next());
+      result.push(value);
+      if (result.length === 1) {
+        try {
+          iter.throw?.(new Error("stopping"));
+        } catch (_err) {
+          passed = true;
+        }
+        break;
+      }
+    }
+
+    expect(result).toEqual([1]);
+    expect(passed).toBe(true);
+  });
 });
 
 describe("takeWhile", () => {
@@ -46,5 +108,67 @@ describe("takeWhile", () => {
       ({ value, done } = iter.next());
     }
     expect(value).toEqual(7);
+  });
+
+  it("should respect the return method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = takeWhile(Boolean, f)[Symbol.iterator]();
+    expect(iter.return).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number> = iter.next();
+    while (!done) {
+      result.push(value);
+      if (result.length === 1) {
+        const res = iter.return?.(9);
+        if (res) {
+          ({ done, value } = res);
+        }
+      } else {
+        ({ done, value } = iter.next());
+      }
+    }
+
+    expect(value).toBe(9);
+    expect(result).toEqual([1]);
+  });
+
+  it("should respect the throw method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = takeWhile(Boolean, f)[Symbol.iterator]();
+    expect(iter.throw).toBeDefined();
+    const result: number[] = [];
+    let { done, value }: IteratorResult<number | undefined> = {
+      done: false,
+      value: undefined,
+    };
+
+    let passed = false;
+    while (!done) {
+      ({ done, value } = iter.next());
+      result.push(value);
+      if (result.length === 1) {
+        try {
+          iter.throw?.(new Error("stopping"));
+        } catch (_err) {
+          passed = true;
+        }
+        break;
+      }
+    }
+
+    expect(result).toEqual([1]);
+    expect(passed).toBe(true);
   });
 });

--- a/spec/zip.spec.ts
+++ b/spec/zip.spec.ts
@@ -23,4 +23,27 @@ describe("zip", () => {
       ["c", 3],
     ]);
   });
+
+  it("supports the return value semantic of generator functions", () => {
+    const f = function* () {
+      let n = 3;
+      while (n--) {
+        yield n;
+      }
+
+      return 7;
+    };
+
+    const g = function* () {
+      let n = 4;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = zip(f, g)[Symbol.iterator]();
+    let { done, value } = iter.next();
+    while (!done) ({ done, value } = iter.next());
+    expect(value).toEqual([7, 0]);
+  });
 });

--- a/spec/zip.spec.ts
+++ b/spec/zip.spec.ts
@@ -46,4 +46,77 @@ describe("zip", () => {
     while (!done) ({ done, value } = iter.next());
     expect(value).toEqual([7, 0]);
   });
+
+  it("should respect the return method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const g = function* () {
+      let n = 4;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = zip(f, g)[Symbol.iterator]();
+    expect(iter.return).toBeDefined();
+    const result: number[][] = [];
+    let { done, value }: IteratorResult<number[]> = iter.next();
+    while (!done) {
+      result.push(value);
+      if (result.length === 1) {
+        const res = iter.return?.(9);
+        if (res) {
+          ({ done, value } = res);
+        }
+      } else {
+        ({ done, value } = iter.next());
+      }
+    }
+
+    expect(value).toBe(9);
+    expect(result).toEqual([[1, 3]]);
+  });
+
+  it("should respect the throw method of iterators", () => {
+    const f = function* () {
+      let n = 2;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const g = function* () {
+      let n = 4;
+      while (n--) {
+        yield n;
+      }
+    };
+
+    const iter = zip(f, g)[Symbol.iterator]();
+    expect(iter.throw).toBeDefined();
+    const result: number[][] = [];
+    let { done, value }: IteratorResult<number[]> = iter.next();
+
+    let passed = false;
+    while (!done) {
+      result.push(value);
+      if (result.length === 1) {
+        try {
+          iter.throw?.(new Error("stopping"));
+        } catch (_err) {
+          passed = true;
+        }
+        break;
+      }
+      ({ done, value } = iter.next());
+    }
+
+    expect(result).toEqual([[1, 3]]);
+    expect(passed).toBe(true);
+  });
 });

--- a/src/concat.ts
+++ b/src/concat.ts
@@ -2,7 +2,8 @@ import { Sequable, toIterable } from "./sequable.js";
 
 /**
  * Yields all of the items from sequence a then all of the items of sequence
- * b.
+ * b. NOTE: return values of the sub-iterators are ignored: only yielded
+ * values are propagated similar to e.g. for..of loops.
  *
  * @param a The first sequence to combine.
  * @param b The second sequence to combine.

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -8,10 +8,10 @@ import { Sequable, toIterator } from "./sequable.js";
  * @param sequable The Iterator, Iterable, or generator function sequence
  * to filter.
  */
-export function* filter<F extends (arg: any) => boolean>(
-  pred: F,
-  seq: Sequable<Parameters<F>[0]>,
-): Iterable<Parameters<F>[0]> {
+export function* filter<T>(
+  pred: (x: T) => boolean,
+  seq: Sequable<T>,
+): Iterable<T> {
   const iter = toIterator(seq);
   let { value, done } = iter.next();
   while (!done) {

--- a/src/partition.ts
+++ b/src/partition.ts
@@ -85,7 +85,6 @@ export function partitionBy<P extends (x: any) => boolean>(
           }
           ({ value, done } = iter.next());
           srcDone = Boolean(done);
-          console.log(`value: ${value}, done: ${done}`);
         }
 
         if (value !== undefined) {

--- a/src/take.ts
+++ b/src/take.ts
@@ -25,10 +25,10 @@ export function* take<T>(n: number, sequable: Sequable<T>): Iterable<T> {
  * @param sequable The Iterator, Iterable, or generator function sequence
  * to yield from.
  */
-export function* takeWhile<P extends (x: any) => boolean>(
-  pred: P,
-  sequable: Sequable<Parameters<P>[0]>,
-): Iterable<Parameters<P>[0]> {
+export function* takeWhile<T>(
+  pred: (x: T) => boolean,
+  sequable: Sequable<T>,
+): Iterable<T> {
   const iter = toIterator(sequable);
   let { value, done } = iter.next();
   while (!done && pred(value)) {

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -20,5 +20,5 @@ export function* zip<T, U>(a: Sequable<T>, b: Sequable<U>): Iterable<[T, U]> {
     y = ys.next();
   }
 
-  if (x.value !== undefined && y.value !== undefined) return [x.value, y.value];
+  if (x.value !== undefined || y.value !== undefined) return [x.value, y.value];
 }


### PR DESCRIPTION
Adds tests to test the return value semantics of generator functions and the return and throw methods of iterators. Includes minor bugfixes related.